### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,10 @@ RUN cargo build --release
 
 RUN strip target/release/file-server-rust
 
-FROM alpine:latest AS release
+FROM gcr.io/distroless/cc-debian12 AS release
 WORKDIR /app
 COPY --from=builder /app/target/release/file-server-rust .
 
-ENV ROCKET_ADDRESS=0.0.0.0
-ENV ROCKET_PORT=8000
-EXPOSE 8000
+EXPOSE 8080
 
 CMD ["./file-server-rust"]


### PR DESCRIPTION
### Self Check

- [x] I checked & tested my PR and it works well

## Content of PR

**What changed on this pull request**
- Delete useless script
- Change to [Distroless](https://github.com/GoogleContainerTools/distroless) images instead of `alpine:latest`, to resolve execution error

**Reference**
https://dev.to/mattdark/rust-docker-image-optimization-with-multi-stage-builds-4b6c